### PR TITLE
Update _ds_optzeros.py

### DIFF
--- a/deltasigma/_ds_optzeros.py
+++ b/deltasigma/_ds_optzeros.py
@@ -78,7 +78,7 @@ def ds_optzeros(n, opt=1):
     """
     opt = int(opt)    
     if opt == 0:
-        optZeros = np.zeros((np.ceil(n/2.), ))
+        optZeros = np.zeros((int(np.ceil(n/2.)), ))
     else:
         optZeros = _oznopt[n][opt]
     


### PR DESCRIPTION
Commit for 
--------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/tests/test_ds_optzeros.py", line 41, in test_opt_zeros
    self.res[n][0][0][:, opt], ds.ds_optzeros(i+1, opt),
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/_ds_optzeros.py", line 81, in ds_optzeros
    optZeros = np.zeros((np.ceil(n/2.), ))
TypeError: 'numpy.float64' object cannot be interpreted as an integer