### PR TITLE
Test function for ds_synNTFobj1() 1/2

### DIFF
--- a/deltasigma/_padt.py
+++ b/deltasigma/_padt.py
@@ -49,7 +49,7 @@ def padt(x, n, val=0.):
     else:
         xp = x
     y = np.concatenate(
-                       (val*np.ones((n - xp.shape[0], xp.shape[1])),
+                       (val*np.ones((int(n - xp.shape[0]), int(xp.shape[1]))),
                         xp
                        ), axis=0
                       )


### PR DESCRIPTION
Check solving for
--------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/tests/test_ds_synNTFobj1.py", line 30, in test_ds_synNTFobj1_1
    tv = ds.ds_synNTFobj1(.5, (.9, 2), 64, .1)
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/_ds_synNTFobj1.py", line 41, in ds_synNTFobj1
    z = padt(z, p.shape[0]//2., np.exp(2j*np.pi*f0))
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/_padt.py", line 52, in padt
    (val*np.ones((n - xp.shape[0], xp.shape[1])),
  File "/home/travis/miniconda3/envs/buildenv/lib/python3.5/site-packages/numpy/core/numeric.py", line 203, in ones
    a = empty(shape, dtype, order)
TypeError: 'float' object cannot be interpreted as an integer