### PR TITLE
ERROR: dsdemo3 test: Delta sigma modulator synthesis

### DIFF
--- a/deltasigma/tests/test_dsdemo3.py
+++ b/deltasigma/tests/test_dsdemo3.py
@@ -46,7 +46,7 @@ class TestAxisLabels(unittest.TestCase):
         b = np.concatenate((np.atleast_1d(b[0]), 
                             np.zeros((b.shape[0] - 1,))))
         u = np.linspace(0, 0.6, 30)
-        N = 1e4
+        N = 10000
         T = np.ones((1, N))
         maxima = np.zeros((order, len(u)))
         for i in range(len(u)):


### PR DESCRIPTION
Check for
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/tests/test_dsdemo3.py", line 50, in test_dsdemo3
    T = np.ones((1, N))
  File "/home/travis/miniconda3/envs/buildenv/lib/python3.5/site-packages/numpy/core/numeric.py", line 203, in ones
    a = empty(shape, dtype, order)
TypeError: 'float' object cannot be interpreted as an integer