### PR TITLE
Test function for impL1() 3/4

### DIFF
--- a/deltasigma/_utils.py
+++ b/deltasigma/_utils.py
@@ -521,7 +521,7 @@ def _get_num_den(arg, input=0):
         num, den = ss2tf(A, B, C, D, input=input)
     elif isinstance(arg, lti):
         arx = arg.to_tf()
-        num, den = arg.num, arg.den
+        num, den = arx.num, arx.den
     elif _is_num_den(arg):
         num, den = carray(arg[0]).squeeze(), carray(arg[1]).squeeze()
     elif _is_zpk(arg):


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/tests/test_impL1.py", line 52, in test_impL1_lti
    r4 = ds.impL1(tf, n=10)
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/_impL1.py", line 74, in impL1
    num, den = _get_num_den(arg1)
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/_utils.py", line 524, in _get_num_den
    num, den = arg.num, arg.den
AttributeError: 'ZerosPolesGainContinuous' object has no attribute 'num'