### PR TITLE
Test function for plotSpectrum()

### DIFF
--- a/deltasigma/tests/test_plotSpectrum.py
+++ b/deltasigma/tests/test_plotSpectrum.py
@@ -19,7 +19,7 @@
 import unittest
 import numpy as np
 import deltasigma as ds
-import pylab as plt
+import matplotlib.pyplot as plt
 
 from numpy.fft import fft
 
@@ -54,10 +54,10 @@ class TestPlotSpectrum(unittest.TestCase):
         freq = np.linspace(0, 0.5, N/2 + 1)
         # plotting
         plt.subplot(211)
-        plt.plot(freq, ds.dbv(spec0[:N/2 + 1]), 'c', linewidth=1, label='$S$')
-        plt.hold(True)
+        plt.plot(freq, ds.dbv(spec0[:N//2 + 1]), 'c', linewidth=1, label='$S$')
+        #plt.hold(True)
         spec_smoothed = ds.circ_smooth(np.abs(spec0)**2., 16)
-        plt.plot(freq, ds.dbp(spec_smoothed[:N/2 + 1]), 'b--', linewidth=2,
+        plt.plot(freq, ds.dbp(spec_smoothed[:N//2 + 1]), 'b--', linewidth=2,
                  label='$\\mathrm{circ\\_smooth}(S)$')
         ds.plotSpectrum(spec0, fin, 'r', linewidth=2,
                         label='$\\mathrm{plotSpectrum}(S)$')
@@ -72,11 +72,11 @@ class TestPlotSpectrum(unittest.TestCase):
         ax.set_title('Smoothing and plotting for LOG and LIN axes')
         plt.legend(loc=4)
         plt.subplot(212)
-        plt.plot(freq, ds.dbv(spec0[:N/2 + 1]), 'c', linewidth=1, label='$S$')
-        plt.hold(True)
+        plt.plot(freq, ds.dbv(spec0[:N//2 + 1]), 'c', linewidth=1, label='$S$')
+        #plt.hold(True)
         ds.plotSpectrum(spec0, fin, '--r', linewidth=2,
                         label='$\\mathrm{plotSpectrum}(S)$')
-        plt.plot(freq, ds.dbp(spec_smoothed[:N/2 + 1]), 'b', linewidth=2,
+        plt.plot(freq, ds.dbp(spec_smoothed[:N//2 + 1]), 'b', linewidth=2,
                  label='$\\mathrm{circ\\_smooth}(S)$')
         plt.plot(freq, ds.dbp(Snn*NBW), 'm', linewidth=1.5,
                  label='$\mathrm{from\\ NTF}$')


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/travis/build/Yuki-F-HCU/python-deltasigma/deltasigma/tests/test_plotSpectrum.py", line 57, in test_plotSpectrum
    plt.plot(freq, ds.dbv(spec0[:N/2 + 1]), 'c', linewidth=1, label='$S$')
TypeError: slice indices must be integers or None or have an __index__ method